### PR TITLE
CI using GitHub Workflows

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install platform
         run: |
           arduino-cli core update-index
-          arduino-cli install arduino:avr
+          arduino-cli core install arduino:avr
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -1,0 +1,32 @@
+name: Arduino
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install CLI
+        uses: arduino/setup-arduino-cli@v1.0.0
+
+      - name: Install platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli install arduino:avr
+
+      - name: Install dependencies
+        run: |
+          arduino-cli lib install AccelStepper
+          arduino-cli lib install Adafruit_SleepyDog_Library
+          arduino-cli lib install BME280
+          arduino-cli lib install LiquidCrystal_PCF8574
+          arduino-cli lib install TimerOne
+
+      - name: Compile
+        run: arduino-cli compile --fqbn arduino:avr:uno OpenSourceVentilator/

--- a/OpenSourceVentilator/OpenSourceVentilator.ino
+++ b/OpenSourceVentilator/OpenSourceVentilator.ino
@@ -496,7 +496,7 @@
 
        
 #ifdef I2C
-#define jm_Wire                 // The jm_wire library corrects the longstanding I2C hanging problem with the arduino Wire library.
+//#define jm_Wire                 // The jm_wire library corrects the longstanding I2C hanging problem with the arduino Wire library.
 #ifdef jm_Wire
 #include <jm_Wire.h>              // I2C protocol, contains a workaround for a longstanding issue with the Wire library
                                   // by Jean-Marc Paratte - https://github.com/jmparatte/jm_Wire


### PR DESCRIPTION
For issue #3 I have added a CI workflow to setup the Arduino environment and compile the source. However, I commented out the jm_Wire define statement because, even locally, I have not been able to build with it included.